### PR TITLE
Add package.json to assist with dependency installation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+config/config.js
+.idea/*

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ Requires [node](http://nodejs.org/) and [npm](http://npmjs.org/). You also need 
 
 (You'll need to add all that info to metaphor.js before running the program, otherwise Twitter won't play nice. Don't worry, it's all commented.)
 
-> npm install node-restclient@0.0.1
+Add your twitter auth config into config/config.js.template and rename to config/config.js
 
-> npm install twit@1.1.6
+> npm install
 
-> npm install express@2.5.9
-
-> node fnttb.js
+> npm start

--- a/config/config.js.template
+++ b/config/config.js.template
@@ -1,0 +1,8 @@
+module.exports = {
+    twit: {
+        consumer_key: "changeme",
+        consumer_secret: "changeme",
+        access_token: "changeme",
+        access_token_secret: "changeme"
+    }
+};

--- a/fnttb.js
+++ b/fnttb.js
@@ -12,14 +12,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 var restclient = require('node-restclient');
 var Twit = require('twit');
 
-// insert your twitter app info here
-var T = new Twit({
-  consumer_key:         '1XP8tfz1am1yw6iMPpZ7BV7j4', 
-  consumer_secret:      'pRxvpqto7h1KIEyGXcLYzb5VAvYOs00umQN32JG7JFpGDqiRzQ',
-  access_token:         '728595030378729472-jJeTZ1LqEXchzAWMjk0N2N1W1fk8fc4',
-  access_token_secret:  '7cSLEwO65FDPODGoPTsIpALDgRKTqAMXAWKrCs457O9PF'
-});
+var config = require('./config/config');
 
+// insert your twitter app info here
+var T = new Twit(config.twit);
 
 //Name Segments by Gender and Race
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "FNTTB",
+  "description": "Fantasy Name and Title Twitter Bot (FNTTB)",
+  "repository": "https://github.com/ShameOnATrip/fnttb.git",
+  "author": "ShameOnATrip <jhuddleston5646@gmail.com>",
+  "version": "0.0.1",
+  "dependencies": {
+    "express": "^4.13.4",
+    "node-restclient": "0.0.1",
+    "twit": "^2.2.4"
+  },
+  "scripts": {
+    "start": "node fnttb.js"
+  }
+}


### PR DESCRIPTION
Hey,

I have added a package.json to list details about the project as well as dependencies. Anyone checking out this project will now be able to execute `npm install` to pull in express, node-restclient and twit dependencies instead of installing them with separate commands.

There is also a scripts section including `npm start` which can used instead of `node fnttb.js`

I split out twitter auth config into it's own file in config/config.js. You will need to take a copy of config/config.js.template, rename / fill in details.

Thanks!
